### PR TITLE
Clean userExceptionManager module

### DIFF
--- a/src/accentExporter.py
+++ b/src/accentExporter.py
@@ -492,7 +492,7 @@ class AccentDictionaryParser:
         if not self.kanaMode and not self.dictMode and not self.pitchMode:
             return text, self.audioGraphList;
         else: 
-            return self.ueMng.applyRulesToText(self.noBracketsNoSpaces(self.fStr.replace('[]', '').replace(',]', ']').replace('  ', ' '))), self.audioGraphList;
+            return self.ueMng.apply_rules_to_text(self.noBracketsNoSpaces(self.fStr.replace('[]', '').replace(',]', ']').replace('  ', ' '))), self.audioGraphList;
 
 class AccentExporter:
     def  __init__(self, mw, aqt, UEManager, dictionary,  addon_path, adjustVerbs, separateWord, separateVerbPhrase, ignoreVerbs, dontCombineDict, skipList, parseWithMecab, verbToNoun):
@@ -921,6 +921,3 @@ class AccentExporter:
             return True
         else:
             return False
-
-
-

--- a/src/gui.py
+++ b/src/gui.py
@@ -101,9 +101,9 @@ class JSGui(QScrollArea):
 
     def setupRulesTable(self):
         rt = self.ui.rulesTable
-        self.ueMng.setupModel(self)
+        self.ueMng.setup_model(self)
         rt.setModel(self.ueMng.model)
-        self.ueMng.model.ascendingOrder()
+        self.ueMng.model.ascending_order()
         self.updateRuleCounter()
         tableHeader2 = rt.horizontalHeader()
         tableHeader2.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
@@ -142,7 +142,7 @@ class JSGui(QScrollArea):
     def addRule(self):
         original = self.ui.originalLE.text()
         overwrite = self.ui.overwriteLE.text()
-        added, addId = self.ueMng.addRule(original, overwrite, self.ui.ncAddCB.isChecked(), self.ui.lcAddCB.isChecked(), self)
+        added, addId = self.ueMng.add_rule(original, overwrite, self.ui.ncAddCB.isChecked(), self.ui.lcAddCB.isChecked(), self)
         if added:
             self.ui.originalLE.setText('')
             self.ui.overwriteLE.setText('')
@@ -202,11 +202,11 @@ class JSGui(QScrollArea):
         nc = self.ui.ncAllCB.isChecked() 
         lc = self.ui.lcAllCB.isChecked()
         if nc or lc:
-            self.ueMng.applyRules(self.ueMng.model.sourceModel().ueList, nc, lc, self)
+            self.ueMng.apply_rules(self.ueMng.model.sourceModel().ue_List, nc, lc, self)
 
     def applyEditedRule(self, rule, nc, lc):
         if nc or lc:
-            self.ueMng.applyRules(rule, nc, lc, self)
+            self.ueMng.apply_rules(rule, nc, lc, self)
             self.arMenu.hide()
 
     def setRuleData(self, item, data):
@@ -291,13 +291,13 @@ class JSGui(QScrollArea):
     def initRuleSearch(self):
         text = self.ui.searchRulesLE.text()
         if text == '':
-            self.ueMng.model.ascendingOrder()
-            self.ueMng.model.setFilterByColumn(text)
+            self.ueMng.model.ascending_order()
+            self.ueMng.model.set_filter_by_column(text)
             self.updateRuleCounter()   
             self.ui.rulesTable.scrollToTop()
         else:
-            self.ueMng.model.testData(text)
-            self.ueMng.model.setFilterByColumn(text)
+            self.ueMng.model.test_data(text)
+            self.ueMng.model.set_filter_by_column(text)
             self.updateRuleCounter()   
             self.ui.rulesTable.scrollToTop() 
         return
@@ -311,7 +311,7 @@ class JSGui(QScrollArea):
             foundOriginal = []
             foundOverwrite = []
             text = text.lower()
-            for original, overwrite in self.ueMng.ueList.items():
+            for original, overwrite in self.ueMng.ue_List.items():
                 LOriginal = original.lower()
                 LOverwrite = overwrite.lower()
                 if LOriginal == text:
@@ -337,7 +337,7 @@ class JSGui(QScrollArea):
         fileName, _ = QFileDialog.getSaveFileName(self,"Save Overwrite Rules List", 'overwriterules.json', 'JSON Files (*.json)',
                                                options=QFileDialog.Option.DontUseNativeDialog)
         if fileName:
-            self.ueMng.exportUEList(fileName)
+            self.ueMng.export_ue_list(fileName)
 
 
     def importRules(self):
@@ -383,7 +383,7 @@ class JSGui(QScrollArea):
             self.importW.show()
 
     def ruleListImport(self, window, fileName, combine, overwriteCollides):
-        imported = self.ueMng.importUEList(fileName, combine, overwriteCollides) 
+        imported = self.ueMng.import_ue_list(fileName, combine, overwriteCollides) 
         if imported is not False:
             if not combine:
                 miInfo(str(imported[0]) +' rules have been imported.', level = 'not')
@@ -392,9 +392,9 @@ class JSGui(QScrollArea):
                     miInfo(str(imported[0]) +' rules have been imported.<br>' + str(imported[1]) + ' rules have been overwritten.', level = 'not')
                 else:
                     miInfo(str(imported[0]) +' rules have been imported.<br>' + str(imported[1]) + ' rules have been ignored because they conflicted with existing rules.', level = 'not')
-            self.ueMng.setupModel(self)
+            self.ueMng.setup_model(self)
             self.ui.rulesTable.setModel(self.ueMng.model)
-            self.ueMng.model.ascendingOrder()
+            self.ueMng.model.ascending_order()
             self.updateRuleCounter()
             window.hide()
             

--- a/src/main.py
+++ b/src/main.py
@@ -87,7 +87,7 @@ def setupShortcuts(shortcuts, editor):
     keys.append({ "hotkey": "F2", "name" : 'extra', 'function' : lambda  editor=editor: mw.Exporter.groupExport(editor)})
     keys.append({ "hotkey": "F3", "name" : 'extra', 'function' : lambda  editor=editor: mw.Exporter.individualExport(editor)})
     keys.append({ "hotkey": "F4", "name" : 'extra', 'function' : lambda  editor=editor: mw.Exporter.cleanField(editor)})
-    keys.append({ "hotkey": "F5", "name" : 'extra', 'function' : lambda  editor=editor:  UEManager.openAddMenu(editor)})
+    keys.append({ "hotkey": "F5", "name" : 'extra', 'function' : lambda  editor=editor:  UEManager.open_add_menu(editor)})
     newKeys = shortcuts;
     for key in keys:
         newKeys = list(filter(lambda x: shortcutCheck(x[0], key['hotkey']), newKeys))
@@ -101,7 +101,7 @@ def setupButtons(righttopbtns, editor):
     return righttopbtns  
   editor._links["individualExport"] = lambda editor: mw.Exporter.individualExport(editor)
   editor._links["cleanField"] = lambda editor: mw.Exporter.cleanField(editor)
-  editor._links["openUserExceptionsAdder"] = UEManager.openAddMenu
+  editor._links["openUserExceptionsAdder"] = UEManager.open_add_menu
   iconPath = os.path.join(addon_path, "icons", "userexceptions.svg")
   righttopbtns.insert(0, editor._addButton(
                 icon=iconPath,
@@ -201,7 +201,7 @@ def setupGuiMenu():
     setting.triggered.connect(openGui)
     mw.MigakuMenuSettings.append(setting)
     action = QAction("Add Parsing Overwrite Rule", mw)
-    action.triggered.connect(UEManager.openAddMenu)
+    action.triggered.connect(UEManager.open_add_menu)
     mw.MigakuMenuActions.append(action)
 
     mw.MigakuMainMenu.clear()
@@ -227,7 +227,7 @@ def selectedText(page):
 def addOverwriteRule(self):
     text = selectedText(self)
     if text:
-        UEManager.openAddMenu(self, text)
+        UEManager.open_add_menu(self, text)
 
 def addToContextMenu(self, m):
     a = m.addAction("Add Rule")
@@ -237,7 +237,7 @@ AnkiWebView.addOverwriteRule = addOverwriteRule
 addHook("EditorWebView.contextMenuEvent", addToContextMenu)
 addHook("browser.setupMenus", setupMenu)
 addHook("browser.setupMenus", setupMenu)
-addHook("profileLoaded", UEManager.getUEList)
+addHook("profileLoaded", UEManager.get_ue_list)
 addHook("profileLoaded", accentGraphCss)
 addHook("profileLoaded", mw.CSSJSHandler.injectWrapperElements)    
 addHook("setupEditorButtons", setupButtons)

--- a/src/userExceptionManager.py
+++ b/src/userExceptionManager.py
@@ -1,115 +1,131 @@
 # -*- coding: utf-8 -*-
 # 
-import re
+import re #TODO: Are you using this? 
 import json
-from . import Pyperclip 
 from os.path import join, exists
-from shutil import copyfile
-from aqt.addcards import AddCards
-from .addgui import Ui_Form
-from aqt.qt import *
+from shutil import copyfile #TODO: Are you using this?
+from typing import Union 
+
+from aqt.addcards import AddCards  #TODO: Are you using this? 
+from aqt.qt import QSortFilterProxyModel, QAbstractItemModel, QAbstractTableModel, QModelIndex, QLabel, QWidget, QProgressBar, QIcon, Qt
 from aqt.editor import Editor
-import anki.find
-import codecs
+from anki.find import Finder
+from anki.utils import is_mac
+
+from . import Pyperclip #TODO: Are you using this? 
+from .addgui import Ui_Form
 from .miutils import miInfo, miAsk
 
 class OgOvFilter(QSortFilterProxyModel):
-    def __init__(self, model, parent = None):
-        super(OgOvFilter, self).__init__(parent)
+    """
+    Provides filtering and sorting functionality for a source model.
+    
+    Methods:
+    - set_filter_by_column(self, str_to_compare): Sets the filter string for the column to be filtered.
+    - ascending_order(self): Sorts the rows in ascending order based on the length of the original and overwrite values.
+    - test_data(self, text): Filters the rows based on the filter string and updates the source model's data.
+    - save_list(self, path): Saves the filtered and sorted data to a file.
+    """
+
+    def __init__(self, model: QAbstractItemModel, parent=None):
+        super().__init__(parent)
         self.setSourceModel(model)
         self.insertRows = model.insertRows
-        self.strToCompare = ''
+        self.str_to_compare = ''
 
-    def setFilterByColumn(self, strToCompare):
-        self.strToCompare  = strToCompare
+    def set_filter_by_column(self, str_to_compare: str):
+        self.str_to_compare = str_to_compare
         self.invalidateFilter()
 
-    def ascendingOrder(self):
-        self.sourceModel().ueList = sorted(self.sourceModel().ueList)
+    def ascending_order(self):
+        self.sourceModel().ue_list = sorted(self.sourceModel().ue_list)
 
+    def test_data(self, text: str):
+        """
+        Filters the rows based on the filter string and updates the source model's data.
 
-    def testData(self, text):
-        listBeforeReorder = self.sourceModel().ueList
-        foundOriginal = []
-        foundOverwrite = []
-        notFound = []
+        Args:
+        - text: The filter string to be used for filtering.
+        """
         text = text.lower()
-        for ogOv  in listBeforeReorder:
-            original = ogOv[0]
-            overwrite = ogOv[1]
-            LOriginal = original.lower()
-            LOverwrite = overwrite.lower()
-            if LOriginal == text:
-                foundOriginal.append([original, overwrite])
-            elif text in LOriginal: 
-                foundOriginal.append([original, overwrite])
-            elif LOverwrite == text:
-                foundOverwrite.append([original, overwrite])
-            elif text in LOverwrite: 
-                foundOverwrite.append([original, overwrite])
+        found_original = []
+        found_overwrite = []
+        not_found = []
+
+        for original, overwrite in self.sourceModel().ue_list:
+            if text in original.lower():
+                found_original.append([original, overwrite])
+            elif text in overwrite.lower():
+                found_overwrite.append([original, overwrite])
             else:
-                notFound.append([original, overwrite])   
-        self.sourceModel().ueList = sorted(foundOriginal, key= lambda x: len(x[0])) + sorted(foundOverwrite,  key= lambda x: len(x[1])) + notFound
+                not_found.append([original, overwrite])
 
+        found_original.sort(key=lambda x: len(x[0]))
+        found_overwrite.sort(key=lambda x: len(x[1]))
 
-    def saveList(self, path):
-        ueList = self.sourceModel().ueList
-        self.sourceModel().mng.ueList = ueList
-        with codecs.open(path, "w","utf-8") as outfile:
-            json.dump(ueList, outfile, ensure_ascii=False) 
+        self.sourceModel().ue_list = found_original + found_overwrite + not_found
 
-    def filterAcceptsRow(self, sourceRow, sourceParent ):
-        if self.strToCompare != '':
-            ogIndex = self.sourceModel().index(sourceRow, 0, sourceParent)
-           
-            ovIndex = self.sourceModel().index(sourceRow, 1, sourceParent)
-             
-            if ogIndex.isValid() and ovIndex.isValid():
-                og = self.sourceModel().data(ogIndex)
-                ov = self.sourceModel().data(ovIndex)
-                if self.strToCompare not in og and self.strToCompare not in ov:
-                    return False
-        return True
+    def save_list(self, path: str):
+        ue_list = self.sourceModel().ue_list
+        self.sourceModel().mng.ue_list = ue_list
 
-    def headerData(self, section, orientation, role):
-        if orientation == Qt.Orientation.Vertical and role == Qt.ItemDataRole.DisplayRole:
-            return section + 1
-        return super(OgOvFilter, self).headerData(section, orientation, role)
+        with open(path, "w", encoding="utf-8") as outfile:
+            json.dump(ue_list, outfile, ensure_ascii=False)
 
 
 class RulesModel(QAbstractTableModel):
+    """
+    Main functionalities:
+    - Provides the data for a table view with two columns: "Original" and "Overwrite".
+    - Controls the display of the table view.
+    - Allows filtering and sorting of the data.
+    - Saves the filtered and sorted data to a file.
 
-    def __init__(self, ueList, manager, gui, parent=None):
-        super(RulesModel, self).__init__(parent)
-        self.ueList = ueList
+    Methods:
+    - rowCount(self, index=QModelIndex()): Returns the number of rows in the model.
+    - data(self, index, role=Qt.ItemDataRole.DisplayRole): Returns the data for a given index and role.
+    - removeRows(self, position, rows=1, index=QModelIndex()): Removes rows at the specified position. Returns True if successful, False otherwise.
+    - setData(self, index, value, role=Qt.ItemDataRole.EditRole, over__write_rule__=False, ruleDict=None): Sets the data in the cell at the specified index with the given value. Returns True if successful, False otherwise.
+
+    Fields:
+    - ue_list: The list of data to be displayed in the table view.
+    - mng: The manager object associated with the model.
+    - gui: The GUI object associated with the model.
+    """
+
+    def __init__(self, ue_list, manager, gui, parent=None):
+        super().__init__(parent)
+        self.ue_list = ue_list
         self.mng = manager
         self.gui = gui
         
+    def __rule_is_valid__(self, value: str, rule: str) -> bool:
+        if value == rule:
+            miInfo('The original text and overwrite text cannot be the same.')
+            return False
+        elif not value:
+            miInfo('A rule must be at least one character long.')
+            return False
+        
+        return True
 
-    def rowCount(self, index=QModelIndex()):
-        return len(self.ueList)
-
-    def columnCount(self, index=QModelIndex()):
+    #TODO: Do we need index?
+    def rowCount(self, index=QModelIndex()) -> int:
+        return len(self.ue_list)
+    
+    #TODO: Do we need index?
+    #TODO: No magic number
+    def columnCount(self, index=QModelIndex()) -> int:
         return 2
 
-    def data(self, index, role=Qt.ItemDataRole.DisplayRole):
-        if not index.isValid():
+    def data(self, index: QModelIndex, role=Qt.ItemDataRole.DisplayRole) -> Union[str, None]:
+        if not index.isValid() or index.row() >= len(self.ue_list) or role not in [Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.EditRole]:
             return None
 
-        if not 0 <= index.row() < len(self.ueList):
-            return None
-        if role == Qt.ItemDataRole.DisplayRole or role == Qt.ItemDataRole.EditRole:
-            original = self.ueList[index.row()][0]
-            overwrite = self.ueList[index.row()][1]
-            
-            if index.column() == 0:
-                return original
-            elif index.column() == 1:
-                return overwrite
-        return None
+        original, overwrite = self.ue_list[index.row()]
+        return original if index.column() == 0 else overwrite
 
-
-    def headerData(self, section, orientation, role=Qt.ItemDataRole.DisplayRole):
+    def headerData(self, section: int, orientation: Qt.Orientation, role=Qt.ItemDataRole.DisplayRole) -> Union[str, int, None]:
         if role != Qt.ItemDataRole.DisplayRole:
             return None
 
@@ -118,321 +134,407 @@ class RulesModel(QAbstractTableModel):
                 return "Original"
             elif section == 1:
                 return "Overwrite"
-        if orientation == Qt.Orientation.Vertical:
-            return section + 1;
-        return None
-
-    def insertRows(self, position= False, rows=1, index=QModelIndex(), original= False, overwrite=False):
-        if not position:
-            position = self.rowCount()
-        self.beginInsertRows(QModelIndex(), position, position)
-        for row in range(rows):
             
+        return section + 1 if orientation == Qt.Orientation.Vertical else None
+
+    #TODO: Do we need index?
+    def insertRows(self, position=False, rows=1, index=QModelIndex(), original=False, overwrite=False) -> bool:
+        if not position:
+            position = self.row_count()
+            
+        self.beginInsertRows(QModelIndex(), position, position)
+        
+        for row in range(rows):       
             if original and overwrite:
-                self.ueList.insert(position + row, [original, overwrite])
+                self.ue_list.insert(position + row, [original, overwrite])
+                
         self.endInsertRows()
-        self.mng.saveUEList()
+        self.mng.save_ue_list()
         return True
 
-    def removeRows(self, position, rows=1, index=QModelIndex()):
+    #TODO: Do we need index?
+    def removeRows(self, position: int, rows=1, index=QModelIndex()) -> bool:
         self.beginRemoveRows(QModelIndex(), position, position + rows - 1)
 
-        del self.ueList[position:position+rows]
+        del self.ue_list[position:position+rows]
         self.endRemoveRows()
-        self.mng.saveUEList()
+        self.mng.save_ue_list()
         return True
 
-    def setData(self, index, value, role=Qt.ItemDataRole.EditRole, overwriteRule = False, ruleDict = None):
+    def setData(self, index: QModelIndex, value, role=Qt.ItemDataRole.EditRole, overwrite_rule=False, rule_dict=None) -> bool:
         if role != Qt.ItemDataRole.EditRole:
             return False
 
-        if overwriteRule and ruleDict['row'] < len(self.ueList):
-            rule = self.ueList[ruleDict['row']]
-            rule[0] = ruleDict['og']
-            rule[1] = ruleDict['ov']
-            self.mng.saveUEList()
+        if overwrite_rule and rule_dict['row'] < len(self.ue_list):
+            rule = self.ue_list[rule_dict['row']]
+            rule[0] = rule_dict['og']
+            rule[1] = rule_dict['ov']
+            self.mng.save_ue_list()
             return True
-        elif (index.isValid() and 0 <= index.row() < len(self.ueList)):
-            rule = self.ueList[index.row()]
-            if index.column() == 0 and self.checkRuleValidity(value, rule[1]) and value != rule[0] and self.mng.ruleExists(value, True) is False :
-                rule[0] = value
-            elif index.column() == 1 and self.checkRuleValidity(value, rule[0]) and value != rule[1]:
-                rule[1] = value
-            else:
-                return False
-            self.mng.saveUEList()
-            self.dataChanged.emit(index, index)
-            self.gui.openApplyRuleInquiry([[rule[0], rule[1]]])
-            return True
-        return False
 
-    def checkRuleValidity(self, a, b):
-        if a == b:
-            miInfo('The original text and overwrite text cannot be the same.')
+        if not index.isValid() or index.row() >= len(self.ue_list):
             return False
-        elif a == '':
-            miInfo('A rule must be at least one character long.')
+
+        rule = self.ue_list[index.row()]
+        column = index.column()
+
+        if column == 0 and self.__rule_is_valid__(value, rule[1]) and value != rule[0] and not self.mng.rule_exists(value, True):
+            rule[0] = value
+        elif column == 1 and self.__rule_is_valid__(value, rule[0]) and value != rule[1]:
+            rule[1] = value
+        else:
             return False
+
+        self.mng.save_ue_list()
+        self.dataChanged.emit(index, index)
+        self.gui.openApplyRuleInquiry([[rule[0], rule[1]]])
         return True
-                 
-
-    def flags(self, index):
+             
+    def flags(self, index: QModelIndex) -> Union[Qt.ItemFlag, QAbstractTableModel]:
         if not index.isValid():
             return Qt.ItemFlag.ItemIsEnabled
+        
         return QAbstractTableModel.flags(self, index) | Qt.ItemFlag.ItemIsEditable
 
-class UserExceptionManager:
 
+class UserExceptionManager:
+    """
+    Main functionalities:
+    - Adding, editing, and applying user-defined exception rules to flashcards
+    - Importing and exporting lists of exception rules from/to files
+
+    Methods:
+    - open_add_menu(self, editor=False, text=False): Opens a menu for adding rules.
+    - get_ue_list(self): Gets the User Exception (UE) list.
+    - setup_model(self, gui): Sets up a model for displaying the User Exception (UE) List in a table view.
+    - add_rule(self, original, overwrite, new_cards, learned_cards, parent_widget, add_menu=False): Adds a new rule to the User Exception (UE) List.
+    - rule_exists(self, original, message=False): Check if a rule with the given original value already exists.
+    - apply_rules(self, rule_list, new_cards, learned_cards, parent_widget, notes=False, message=False): Applies the exception rules to the flashcards based on the specified criteria.
+    - apply_rules_to_text(self, text): Applies the rules in the ue_list to the given text.
+    - save_ue_list(self): Saves the list of rules to a file. If a model is set, the list is saved using the model's saveList method. Otherwise, the list is saved to a file using the json.dump function.
+    - import_ue_list(self, file_name, combine, overwrite_collides): Imports a list of exception rules from a file, optionally combining or overwriting existing rules.
+    - export_ue_list(self, file_name): Exports the list of exception rules to a file.
+
+    Fields:
+    - mw: The main window object of Anki.
+    - addon_path: The path to the addon.
+    - list_path: The path to the file where the exception rules are stored.
+    - active_fields: A dictionary containing the active fields for each note type.
+    - model: The model used for filtering and sorting the exception rules.
+    - ue_list: The list of user-defined exception rules.
+    """
 
     def  __init__(self,mw, addon_path):
         self.mw = mw
         self.addon_path = addon_path
-        self.listPath = False 
-        self.activeFields = False
+        self.list_path = False 
+        self.active_fields = False
         self.model = False
 
-    def getListPath(self):
+    def __get_list_path__(self) -> str:
         return join(self.mw.col.media.dir(), '_userExceptionList.json')
 
-    def updateCount(self, counter):
-        counter.setText('Rule Count: ' + str(len(self.ueList)))
-
-    def openAddMenu(self, editor = False, text = False):
+    def __update_count__(self, counter: QLabel):
+        counter.setText(f'Rule Count: {len(self.ue_list)}')
+        
+    def __set_add_menu_widget__(self, editor: bool) -> QWidget:
         if editor:
-            if isinstance(editor, Editor):
-                self.addMenu = QWidget(editor.web)
-            else:
-                self.addMenu = QWidget(editor)
+            return QWidget(editor.web) if isinstance(editor, Editor) else QWidget(editor)
+
+        return QWidget(self.mw)
+    
+    def __add_rule_clear_text__(self):
+        if self.add_rule(self.add_menu.ui.originalLE.text(), self.add_menu.ui.overwriteLE.text(), self.add_menu.ui.ncAddCB.isChecked(), self.add_menu.ui.lcAddCB.isChecked(), self.add_menu, True):
+            self.add_menu.ui.originalLE.clear()
+            self.add_menu.ui.overwriteLE.clear()
+            
+    def __load__ue_list_from_json__(self):
+        with open(self.list_path, "r", encoding="utf-8") as list_file:
+            return json.load(list_file)
+        
+    def __write_rule__(self, original: str, overwrite: str):
+        if self.model:
+            self.model.insertRows(original=original, overwrite=overwrite)
         else:
-            self.addMenu = QWidget(self.mw)
-        self.addMenu.setWindowIcon(QIcon(join(self.addon_path, 'icons', 'migaku.png')))
-        self.addMenu.setWindowFlags(Qt.WindowType.Dialog | Qt.WindowType.MSWindowsFixedSizeDialogHint)
-        self.addMenu.ui = Ui_Form()
-        self.addMenu.ui.setupUi(self.addMenu)
-        self.updateCount(self.addMenu.ui.listCount)
+            self.ue_list.append([original, overwrite])
+            
+        self.save_ue_list()
+        
+    def __get_active_fields__(self) -> dict:
+        active_fields_config = self.__get_config__()['Active_fields']
+        active_fields = {}
+        
+        for af in active_fields_config:
+            split_af = af.split(';')
+            note_type = split_af[2]
+            field = split_af[4]
+            
+            active_fields.setdefault(note_type, []).append(field)
+                
+        return active_fields
+    
+    def __get_all_notes__(self) -> list:
+        return Finder(self.mw.col).findNotes('')
+    
+    def __card_meets_criteria__(self, cards: list, new_cards: bool, learned_cards: bool) -> bool:
+        return any(
+            (card.type == 0 and new_cards)
+            or ((card.type in [1, 2]) and learned_cards)
+            for card in cards
+        )
+        
+    def __get_progress_widget__(self, parent_widget, title: str) -> tuple[QWidget, QProgressBar]:
+        progress_widget = QWidget(parent_widget, Qt.WindowType.Window)
+        progress_widget.setWindowTitle(title)
+        progress_widget.setFixedSize(400, 70)
+        progress_widget.setWindowModality(Qt.WindowModality.ApplicationModal)
+        
+        bar = QProgressBar(progress_widget)       
+        bar.setFixedSize(380 if is_mac else 390, 50)            
+        bar.move(10,10)
+        
+        per = QLabel(bar)
+        per.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        
+        progress_widget.show()
+        return progress_widget, bar
+    
+    def __apply_rules_to_field__(self, notes: list, checkpointed: bool, new_cards: bool, learned_cards: bool, rule_list: list[tuple[str, str]], bar: QProgressBar) -> tuple[int, int]:
+        altered = 0
+        applied_rules = 0
+        
+        for it, nid in enumerate(notes, start=1):
+            note = self.mw.col.get_note(nid)
+            already_altered = False
+
+            if not self.__card_meets_criteria__(note.cards(), new_cards, learned_cards):
+                continue
+
+            note_type = note.note_type()
+
+            if note_type['name'] in self.active_fields:
+                fields = self.mw.col.models.field_names(note.note_type())
+
+                for field in fields:
+                    if field not in self.active_fields[note_type['name']]:
+                        continue
+                    
+                    for original, overwrite in rule_list:
+                        if original not in note[field]:
+                            continue
+                        
+                        if not already_altered:
+                            altered += 1
+
+                        if not checkpointed:
+                            self.mw.checkpoint('Overwrite Rule Application')
+                            checkpointed = True
+
+                        already_altered = True
+                        applied_rules += 1
+                        note[field] = note[field].replace(original, overwrite)
+
+            bar.setValue(it)
+            self.mw.app.processEvents()
+            
+            return altered, applied_rules
+        
+    def __get_config__(self):
+        return self.mw.addonManager.getConfig(__name__)   
+
+    def open_add_menu(self, editor=False, text=False):
+        self.add_menu = self.__set_add_menu_widget__(editor)            
+        self.add_menu.setWindowIcon(QIcon(join(self.addon_path, 'icons', 'migaku.png')))
+        self.add_menu.setWindowFlags(Qt.WindowType.Dialog | Qt.WindowType.MSWindowsFixedSizeDialogHint)
+        self.add_menu.ui = Ui_Form()
+        self.add_menu.ui.setupUi(self.add_menu)
+        self.__update_count__(self.add_menu.ui.listCount)
+        
         if not text and editor:
             text = editor.web.selectedText()
+            
         if text:
-            self.addMenu.ui.originalLE.setText(text)
-            self.addMenu.ui.overwriteLE.setFocus()
-        self.addMenu.show()
-        self.addMenu.ui.addRuleButton.clicked.connect(self.addRuleAndClearText)
-        
+            self.add_menu.ui.originalLE.setText(text)
+            self.add_menu.ui.overwriteLE.setFocus()
+            
+        self.add_menu.show()
+        self.add_menu.ui.addRuleButton.clicked.connect(self.__add_rule_clear_text__)      
 
+    def get_ue_list(self):
+        self.list_path = self.__get_list_path__()
+        self.active_fields = False
+        self.ue_list = self.__load__ue_list_from_json__() if exists(self.list_path) else []
 
-    def addRuleAndClearText(self):
-        if self.addRule(self.addMenu.ui.originalLE.text(), self.addMenu.ui.overwriteLE.text(), self.addMenu.ui.ncAddCB.isChecked(), self.addMenu.ui.lcAddCB.isChecked(), self.addMenu, True):
-            self.addMenu.ui.originalLE.setText('')
-            self.addMenu.ui.overwriteLE.setText('')
-
-    def loadUEListFromJSON(self):
-        with codecs.open(self.listPath, "r", "utf-8") as listFile:
-            return json.load(listFile)
-
-    def getUEList(self):  # loads UE List into a var from file, or returns an empty list
-        self.listPath = self.getListPath()
-        self.activeFields = False
-        if exists(self.listPath): 
-            self.ueList = self.loadUEListFromJSON()
-        else:
-            self.ueList = []
-    
-
-    def setupModel(self, gui):
-        self.proxyFilter = OgOvFilter(RulesModel(self.ueList, self, gui))
+    def setup_model(self, gui):
+        self.proxyFilter = OgOvFilter(RulesModel(self.ue_list, self, gui))
         self.model = self.proxyFilter
         self.proxyFilter.setFilterKeyColumn(0)
 
-    def addRule(self, original, overwrite, newCards, learnedCards, parentWidget, addMenu = False):
-        if original == '' or overwrite == '':
+    def add_rule(self, original: str, overwrite: str, new_cards: bool, learned_cards: bool, parent_widget, add_menu=False) -> tuple[bool, Union[bool, int]]:
+        """
+        Adds a new rule to the User Exception (UE) List.
+
+        Args:
+            original (str): The original text for the rule.
+            overwrite (str): The text to overwrite the original text.
+            newCards (bool): Indicates whether the rule should be applied to new cards.
+            learnedCards (bool): Indicates whether the rule should be applied to learned cards.
+            parentWidget (object): The parent widget for displaying messages.
+            add_menu (bool, optional): Indicates whether the rule should be added to a menu. Defaults to False.
+
+        Returns:
+            A tuple containing two elements:
+                - bool: True if the rule was successfully added or updated, False otherwise.
+                - bool or int: False if the original or overwrite fields are empty, or if the original and overwrite fields contain the same text. The ID of the existing rule if it was overwritten.
+        """
+        if not original or not overwrite:
             miInfo('The original and overwrite fields should not be empty.', level='not')
-            return False, False;
+            return False, False
+        
         if original == overwrite:
             miInfo('The original and overwrite fields should not contain the same text.', level='not')
-            return False, False;
-        foundId = self.ruleExists(original)
+            return False, False
+        
+        found_id = self.rule_exists(original)
         edit = False
-        if foundId is not False:
-            if not miAsk('The rule "' + original + '" => "' + self.ueList[foundId][1] +'" already overwrites the given text. Would you like to overwrite it with your new rule?'):
+        
+        if found_id:
+            if not miAsk(f'The rule "{original}" => "{self.ue_list[found_id][1]}" already overwrites the given text. Would you like to overwrite it with your new rule?'):
                 return False, False
-            else:
-                edit = True
+
+            edit = True
+        
         if edit:
-            self.model.setData(None, None, Qt.ItemDataRole.EditRole, True, {'row': foundId, 'og': original, 'ov': overwrite})
+            self.model.setData(None, None, Qt.ItemDataRole.EditRole, True, {'row': found_id, 'og': original, 'ov': overwrite})
         else:
-            self.writeRule(original, overwrite)
-        if addMenu:
-            self.updateCount(self.addMenu.ui.listCount)
+            self.__write_rule__(original, overwrite)
+            
+        if add_menu:
+            self.__update_count__(self.add_menu.ui.listCount)
 
-        if newCards or learnedCards:
-            self.applyRules([[original, overwrite]],  newCards, learnedCards, parentWidget) 
+        if new_cards or learned_cards:
+            self.apply_rules([[original, overwrite]],  new_cards, learned_cards, parent_widget) 
 
-        return True, foundId;
+        return True, found_id
 
-    def ruleExists(self, original, message = False):
+    def rule_exists(self, original: str, message=False) -> Union[int, bool]:
+        """
+        Check if a rule with the given original value already exists.
 
-        for idx, ogOv in enumerate(self.ueList):
+        Args:
+            original (str): The original value of a rule.
+            message (bool, optional): Whether to display an error message if the rule exists. Defaults to False.
+
+        Returns:
+            int or bool: The index of the rule if it exists, otherwise False.
+        """
+        for idx, ogOv in enumerate(self.ue_list):
             if original == ogOv[0]:
                 if message:
-                    miInfo('A rule with this original value already exists ("' + original +'" => "' + self.ueList[idx][1] + '""), please ensure that you are defining a unique value.', level='err')
+                    miInfo(
+                        f'A rule with this original value already exists ("{original}" => "{self.ue_list[idx][1]}""), please ensure that you are defining a unique value.',
+                        level='err',
+                    )
                 return idx
+            
         return False
 
-    def writeRule(self, original, overwrite):
-        if self.model:
-            self.model.insertRows(original= original, overwrite= overwrite)
-        else:
-            self.ueList.append([original, overwrite])
-        self.saveUEList()
-        
-    def getActiveFields(self):
-        activeFieldsConfig = self.getConfig()['ActiveFields']
-        activeFields = {}
-        for af in activeFieldsConfig:
-            splitAf = af.split(';')
-            noteType = splitAf[2]
-            field = splitAf[4]
-            if noteType not in activeFields:
-                activeFields[noteType] = [field]
-            else:
-                activeFields[noteType].append(field)
-        return activeFields
+    def apply_rules(self, rule_list: list[tuple[str, str]], new_cards: bool, learned_cards: bool, parent_widget, notes: [list] = None, message: [bool] = False):
+        self.active_fields = self.__get_active_fields__()
 
-    def getAllNotes(self):
-        return anki.find.Finder(self.mw.col).findNotes('')
+        if notes is None:
+            notes = self.__get_all_notes__()
 
-
-    def cardMeetsCriteria(self, cards, newCards, learnedCards):
-        for card in cards:
-            if (card.type == 0 and newCards) or ((card.type == 1 or card.type == 2) and learnedCards):
-                return True
-        return False
-    
-    def getProgressWidget(self, parentWidget, title):
-        progressWidget = QWidget(parentWidget, Qt.WindowType.Window)
-        progressWidget.setWindowTitle(title)
-        layout = QVBoxLayout()
-        progressWidget.setFixedSize(400, 70)
-        progressWidget.setWindowModality(Qt.WindowModality.ApplicationModal)
-        bar = QProgressBar(progressWidget)
-        if is_mac:
-            bar.setFixedSize(380, 50)
-        else:
-            bar.setFixedSize(390, 50)
-        bar.move(10,10)
-        per = QLabel(bar)
-        per.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        progressWidget.show()
-        return progressWidget, bar; 
-
-    def applyRules(self, ruleList, newCards, learnedCards, parentWidget, notes = False, message = False):
-        self.activeFields = self.getActiveFields()
-        if not notes:
-            notes = self.getAllNotes()
-        altered = 0
-        appliedRules = 0
         checkpointed = False
-        progWid, bar = self.getProgressWidget(parentWidget, 'Applying Overwrite Rule(s)...')   
+        prog_wid, bar = self.__get_progress_widget__(parent_widget, 'Applying Overwrite Rule(s)...')
         bar.setMinimum(0)
         bar.setMaximum(len(notes))
-        it = 0
-        for nid in notes:
-            note = self.mw.col.get_note(nid)
-            alreadyAltered = False
-            if not self.cardMeetsCriteria(note.cards(), newCards, learnedCards):
-                continue
-            noteType = note.note_type()
-            if noteType['name'] in self.activeFields:
-                fields = self.mw.col.models.field_names(note.note_type())
-                for field in fields:
-                    if field in self.activeFields[noteType['name']]:
-                        for ogOv in ruleList:
-                            original = ogOv[0] 
-                            overwrite = ogOv[1]
-                            if original in note[field]:
-                                if not alreadyAltered:
-                                    altered += 1
-                                if not checkpointed:
-                                    self.mw.checkpoint('Overwrite Rule Application')
-                                    checkpointed = True
-                                alreadyAltered = True
-                                appliedRules += 1
-                                note[field] = note[field].replace(original, overwrite)
-                        note.flush()
-            it += 1
-            bar.setValue(it)
-            self.mw.app.processEvents()            
-        self.mw.reset()
-        progWid.hide()
-        miInfo('Rule(s) have been applied ' + str(appliedRules) + ' times.<br>' + str(altered) + ' notes have been altered.' , parent = parentWidget, level='not')
-    
-    def applyRulesToText(self, text):
         
-        for ogOv in self.ueList:
-            original = ogOv[0] 
-            overwrite = ogOv[1]
+        altered, applied_rules = self.__apply_rules_to_field__(notes, checkpointed, new_cards, learned_cards, rule_list, bar)          
+
+        self.mw.reset()
+        prog_wid.hide()
+        
+        if message:
+            miInfo(
+                f'Rule(s) have been applied {str(applied_rules)} times.<br>{str(altered)} notes have been altered.',
+                parent=parent_widget,
+                level='not',
+            )  
+    
+    def apply_rules_to_text(self, text: str) -> str:
+        for original, overwrite in self.ue_list:
             if original in text:
                 text = text.replace(original, overwrite)
+                
         return text          
 
-    def saveUEList(self):  #saves UE List to file
+    def save_ue_list(self):
         if not self.model: 
-            ueList = self.ueList
-            with codecs.open(self.listPath, "w","utf-8") as outfile:
-                json.dump(ueList, outfile, ensure_ascii=False) 
+            with open(self.list_path, "w", encoding="utf-8") as outfile:
+                json.dump(self.ue_list, outfile, ensure_ascii=False) 
         else:
-            self.model.saveList(self.listPath)
+            self.model.save_list(self.list_path)
 
-    def importUEList(self, fileName, combine, overwriteCollides):  #imports new list overwrite if desired
+    def import_ue_list(self, file_name: str, combine: bool, overwrite_collides: bool) -> Union[list[int, int], bool]:
+        """
+        Imports a new list of rules from a file.
+
+        The new list can be combined with the existing list, and colliding rules can be overwritten based on the combine and overwriteCollides flags.
+
+        Args:
+            fileName (str): The name of the file from which the new list of rules will be imported.
+            combine (bool): A flag indicating whether the new list of rules should be combined with the existing list.
+            overwriteCollides (bool): A flag indicating whether colliding rules should be overwritten.
+
+        Returns:
+            list: A list containing the total number of imported rules and the number of ignored or overwritten rules.
+            False: If the overwrite rules list could not be imported.
+        """
         try:
-            with open(fileName, "r", encoding="utf-8") as importedList:
-                newList = json.load(importedList)
+            with open(file_name, "r", encoding="utf-8") as imported_list:
+                new_list = json.load(imported_list)
 
-            if combine:
-                tempUEList = self.model.sourceModel().ueList.copy()
-                dictUEList = dict(tempUEList)
-                totalImported = 0
-                ignoredOrOverwritten = 0
-                for ogOv in newList:
-                    if len(ogOv) != 2:
-                        miInfo('The overwrite rules list could not be imported. Please make sure the target file is a valid overwrite rules list and try again.', level='err')
-                        return False
-                    original = ogOv[0]  
-                    overwrite = ogOv[1]
-                    if not isinstance(original, str) or not isinstance(overwrite, str):
-                        miInfo('The overwrite rules list could not be imported. Please make sure the target file is a valid overwrite rules list and try again.', level='err')
-                        return False
-                    if overwriteCollides:
-                        if original in dictUEList:
-                            ignoredOrOverwritten += 1
-                            tempUEList.remove([original, dictUEList[original]])
-                        tempUEList.append([original, overwrite])
-                        totalImported += 1
-                    else:
-                        if original not in dictUEList:
-                            tempUEList.append([original, overwrite])
-                            totalImported += 1
-                        else:
-                            ignoredOrOverwritten += 1
-                self.model.sourceModel().ueList = tempUEList
-                self.saveUEList()
+            if not combine:
+                self.model.sourceModel().ue_list = new_list
+                self.save_ue_list()
+
+                return [len(self.ue_list), 0]
+
+            temp_ue_list = self.model.sourceModel().ue_list.copy()
+            dict_ue_list = dict(temp_ue_list)
+            total_imported = 0
+            ignored_or_overwritten = 0
+
+            for original, overwrite in new_list:
+                if not original or not overwrite or not isinstance(original, str) or not isinstance(overwrite, str):
+                    miInfo('The overwrite rules list could not be imported. Please make sure the target file is a valid overwrite rules list and try again.', level='err')
+                    return False
                 
-                return [totalImported, ignoredOrOverwritten]       
-            else:
-                self.model.sourceModel().ueList = newList
-                self.saveUEList()
-         
-                return [len(self.ueList), 0]
-        except:
+                if original in dict_ue_list:
+                    ignored_or_overwritten += 1
+                    
+                    if overwrite_collides:
+                        temp_ue_list.remove([original, dict_ue_list[original]])
+                        
+                if overwrite_collides or original not in dict_ue_list:
+                    temp_ue_list.append([original, overwrite])
+                    total_imported += 1    
+                    
+            self.model.sourceModel().ue_list = temp_ue_list
+            self.save_ue_list()
+
+            return [total_imported, ignored_or_overwritten]       
+
+        except Exception:
             miInfo('The overwrite rules list could not be imported. Please make sure the target file is a valid overwrite rules list and try again.', level='err')
             return False
-    
-    def getConfig(self):
-        return self.mw.addonManager.getConfig(__name__)
 
-    def exportUEList(self, fileName): #allow user to save a copy of their list where they want
-        if not fileName.endswith('.json'):
-            fileName += '.json'
-        with open(fileName, 'w', encoding='utf-8') as outfile:
-            json.dump(self.ueList, outfile, ensure_ascii=False)
-        miInfo('The overwrite rules list has been exported to "' + fileName +'"', level='not')
+    def export_ue_list(self, file_name: str):
+        if not file_name.endswith('.json'):
+            file_name += '.json'
+            
+        with open(file_name, 'w', encoding='utf-8') as outfile:
+            json.dump(self.ue_list, outfile, ensure_ascii=False)
+            
+        miInfo(f'The overwrite rules list has been exported to "{file_name}"', level='not')


### PR DESCRIPTION
I did this to practice. After finishing I thought it could be useful as it could be easier to work with a cleaner code. If is not useful I will take no offense, I am still learning after all. If the PR is accepted I may do the same with the rest of the modules in the future.

- Removed codecs module as it is not needed in Python 3.
- Followed PEP8.
- Refactored the code without changing its functionality.
- Added docstrings and type hints.
- Added #TODO: comments to imports and arguments that seem not to be used so someone more familiar with the code can check if they are needed now or in the future.